### PR TITLE
test for spherical harmonics

### DIFF
--- a/src/bfunctions.cpp
+++ b/src/bfunctions.cpp
@@ -85,15 +85,18 @@ std::complex<double> B_function_Engine::eval_spherical_harmonics(const Quantum_N
     // Evaluates Spherical Harmonics Y_l^m(theta,phi)
     auto pi = bm::constants::pi<double>();
     std::complex<double>  i(0,1);
+
     auto m = quantumNumbers.m;
     auto l = quantumNumbers.l;
-    auto Plm = bm::legendre_p(l,abs(m),std::cos(theta)); //Associated Legendre Polynomial
+    auto Plm = bm::legendre_p(l,m,std::cos(theta)); //Associated Legendre Polynomial
 
-
-    auto Y = pow(i,m+abs(m));
-    Y *= pow( ( (2*l + 1) * bm::factorial<double>(l-abs(m)) ) / (4*pi*(bm::factorial<double>(l+abs(m)))) , 1/2);
+    //Using Wikipedia's accoustics definition to stay consistent with legendre_p function in boost
+    // which includes the Condon-Shortley phase term
+    std::complex<double> Y;
+    Y = 1;
+    Y *= pow( ( (2*l + 1) * bm::factorial<double>(l-m) ) / (4 * pi * bm::factorial<double>(l + m)) , 1.0 / 2);
     Y *= Plm;
-    Y *= std::exp(i* std::complex<double>(m*phi,1));
+    Y *= std::exp(std::complex<double>(0,m*phi));
 
     return Y;
 }//eval_spherical_harmonics

--- a/test/test-math.cpp
+++ b/test/test-math.cpp
@@ -3,7 +3,6 @@
 #include <math.h>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/reporters/catch_reporter_event_listener.hpp>
-#include <catch2/reporters/catch_reporter_registrars.hpp>
 #include "coordinates.h"
 
 namespace bm = boost::math;
@@ -34,6 +33,20 @@ TEST_CASE( "shift_first_center_to_origin ", "[homeier]" ) {
     CHECK(abs(r2_shifted[0]-1) == 0);
     CHECK(abs(r2_shifted[1]-1) == 0);
     CHECK(abs(r2_shifted[2]+4) == 0);
+
+}
+
+TEST_CASE( "Evaluate Spherical Harmonics ", "[b_func_engine]" ) {
+    auto pi = bm::constants::pi<double>();
+    Quantum_Numbers q1 = {4,2,1};
+    Quantum_Numbers q2 = {4,2,-1};
+    double theta = pi/4;
+    double phi = 0;
+    B_function_Engine b_func_engine;
+    auto Y1 = b_func_engine.eval_spherical_harmonics(q1,theta,phi);
+    auto Y2 = b_func_engine.eval_spherical_harmonics(q2,theta,phi);
+    CHECK(abs(Y1 - std::complex<double>(-0.3862742020231,0)) < 0.001) ;
+    CHECK(abs(Y2 - std::complex<double>(0.3862742020231,0)) < 0.001) ;
 
 }
 


### PR DESCRIPTION
eval_spherical_harmonics evaluates Ylm without including the Condon-Shortley phase term as it is already included in the associated legendre polynomial evaluation function legendre_p from the boost library
